### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Clamd by default connects to 9321 port in localhost. You can also configure the
 host, port, open_timeout(seconds), read_timeout(seconds) and chunk_size(bytes).
 Refer the following code to configure Clamd.
 
-    Client.configure do |config|
+    Clamd.configure do |config|
       config.host = 'localhost'
       config.port = 9321
       config.open_timeout = 5


### PR DESCRIPTION
Fixed typo `Client.configure` -> `Clamd.configure`

```ruby
%irb
>> require "clamd"
=> true
>> Clamd.configure
=> #<Clamd::Configuration:0x00007fc13b8d1540 @host="localhost", @port=9321, @open_timeout=5, @read_timeout=30, @chunk_size=10240>
```